### PR TITLE
Update version pinnings for bqplot in package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -36,7 +36,7 @@
     "d3": "^3.5.16",
     "lodash": "^4.17.4",
     "three": "^0.91.0",
-    "bqplot": "^0.5.0-alpha.0",
+    "bqplot": "^0.5.2",
     "is-typedarray": "^1.0.0",
     "jupyter-dataserializers": "^1.1.2",
     "raw-loader": "^0.5.1"


### PR DESCRIPTION
@maartenbreddels - does this seem ok? This will hopefully fix the Jupyter Lab install for glue-jupyter.