### PR TITLE
fix(lab3): enable deduplication of d3-selection, and do not bundle

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -46,6 +46,7 @@
     "d3-contour": "^1.3.2",
     "d3-geo": "^1.11.6",
     "d3-selection-multi": "^1.0.1",
+    "d3-selection": "^1",
     "is-typedarray": "^1.0.0",
     "jupyter-dataserializers": "^1.3.1",
     "lodash": "^4.17.4",
@@ -63,6 +64,12 @@
       "bqplot": {
         "bundled": false,
         "singleton": true
+      },
+      "d3": {
+        "bundled": false
+      },
+      "d3-selection": {
+        "bundled": false
       },
       "threejs": {
         "bundled": false


### PR DESCRIPTION
This is the other side of https://github.com/bqplot/bqplot/pull/1276 so we can read events, which enables the MouseInteraction to work in jlab3.