### PR TITLE
feat: keydown/keyup event support

### DIFF
--- a/examples/mouse.ipynb
+++ b/examples/mouse.ipynb
@@ -109,8 +109,6 @@
     "def on_mouse_msg(interaction, data, buffers):\n",
     "    # it might be a good idea to throttle on the Python side as well, for instance when many computations\n",
     "    # happen, we can effectively ignore the queue of messages\n",
-    "    if data['event'] in ['click', 'dblclick', 'contextmenu']:\n",
-    "        widget_label.value = f'click {data}'\n",
     "    if data['event'] == 'mousemove':\n",
     "        domain_x = data['domain']['x']\n",
     "        domain_y = data['domain']['y']\n",
@@ -129,7 +127,9 @@
     "        widget_label.value = \"Bye!\"\n",
     "    elif data['event'] == 'mouseenter':\n",
     "        widget_label.value = \"Almost there...\"  # this is is not visible because mousemove overwrites the msg\n",
-    "    \n",
+    "    else:\n",
+    "        widget_label.value = f'click {data}'\n",
+    "        \n",
     "interaction.on_msg(on_mouse_msg)"
    ]
   },


### PR DESCRIPTION
this gives us keydown and keyup event support, similar to ipyevents we grab focus when the mouse moves into the div element of the Figure. Note that we also send the last mouse coordinates with the key events.