### PR TITLE
feat: compose MouseInteraction with other interacts

### DIFF
--- a/bqplot_image_gl/interacts.py
+++ b/bqplot_image_gl/interacts.py
@@ -1,8 +1,13 @@
 from bqplot.interacts import BrushSelector, Interaction
 from bqplot.scales import Scale
-from traitlets import Float, Unicode, Dict, Instance, Int
+from traitlets import Float, Unicode, Dict, Instance, Int, List
 from ipywidgets.widgets.widget import widget_serialization
 from bqplot_image_gl._version import __version__
+
+
+drag_events = ["dragstart", "dragmove", "dragend"]
+mouse_events = ['click', 'dblclick', 'mouseenter', 'mouseleave', 'contextmenu', 'mousemove']
+keyboard_events = ['keydown', 'keyup']
 
 
 class BrushEllipseSelector(BrushSelector):
@@ -93,3 +98,6 @@ class MouseInteraction(Interaction):
         .tag(sync=True, dimension='y', **widget_serialization)
     cursor = Unicode('auto').tag(sync=True)
     move_throttle = Int(50).tag(sync=True)
+    next = Instance(Interaction).tag(sync=True, **widget_serialization)
+    events = List(Unicode, default_value=drag_events + mouse_events + keyboard_events,
+                  allow_none=True).tag(sync=True)

--- a/examples/mouse.ipynb
+++ b/examples/mouse.ipynb
@@ -79,17 +79,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sufficient-shirt",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bqplot_image_gl.interacts import MouseInteraction"
+    "from bqplot_image_gl.interacts import MouseInteraction, keyboard_events, mouse_events\n",
+    "from bqplot import PanZoom"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "empirical-model",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,11 +99,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "known-possession",
    "metadata": {},
    "outputs": [],
    "source": [
-    "interaction = MouseInteraction(x_scale=scales_image['x'], y_scale=scales_image['y'], move_throttle=70)\n",
+    "# if we want to work together with PanZoom, we don't want to processess drag events\n",
+    "panzoom = PanZoom(scales={'x': [scales_image['x']], 'y': [scales_image['y']]})\n",
+    "interaction = MouseInteraction(x_scale=scales_image['x'], y_scale=scales_image['y'], move_throttle=70, next=panzoom,\n",
+    "                               events=keyboard_events + mouse_events)\n",
     "figure.interaction = interaction\n",
     "def on_mouse_msg(interaction, data, buffers):\n",
     "    # it might be a good idea to throttle on the Python side as well, for instance when many computations\n",
@@ -136,7 +137,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "federal-domestic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cherry pick particular events:\n",
+    "# interaction.events = ['click']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
For instance to make MouseInteractions work with PanZoom, for this specific case to work
we should not listen to the drag events, and for this we also need
to filter on those.

Closes #42
Closes #43

cc @pllim