### PR TITLE
fix: wait for view promises to give them time to create the DOM

### DIFF
--- a/js/lib/ViewListener.js
+++ b/js/lib/ViewListener.js
@@ -44,6 +44,9 @@ class ViewListenerModel extends base.DOMWidgetModel {
         this._cleanups.forEach((c) => c());
 
         const views = await this._getViews();
+        await Promise.all(views.map((view) => view.displayed));
+        await Promise.all(views.map((view) => view.layoutPromise));
+
         this.set('view_data', {}) // clear data
         const selector = this.get('css_selector');
         // initial fill
@@ -72,8 +75,12 @@ class ViewListenerModel extends base.DOMWidgetModel {
         views.forEach((view) => {
             let el = view.el;
             el = selector ? el.querySelector(selector) : el;
-            const {x, y, width, height} = el.getBoundingClientRect();
-            view_data[view.cid] = {x, y, width, height};
+            if(el) {
+                const {x, y, width, height} = el.getBoundingClientRect();
+                view_data[view.cid] = {x, y, width, height};
+            } else {
+                console.error('could not find element with css selector', selector);
+            }
         });
         this.set('view_data', view_data)
         this.save_changes();


### PR DESCRIPTION
Some views such as https://github.com/bqplot/bqplot/blob/1c3c0abb474f4ccd0bbf4620f3a86c0d6c13454b/js/src/Figure.ts#L100 wait for the `displayed` and `layoutPromise` before creating DOM elements. We now wait for these so we don't query the DOM before they are created.
