### PR TITLE
fix: do not cull lines

### DIFF
--- a/js/lib/linesgl.js
+++ b/js/lib/linesgl.js
@@ -73,6 +73,7 @@ class LinesGLView extends bqplot.Lines {
         this.geometry = new LineGeometry();
         this._updateGeometry();
         this.line = new Line2(this.geometry, this.material);
+        this.line.frustumCulled = false;
 
         this.camera = new THREE.OrthographicCamera( 1 / - 2, 1 / 2, 1 / 2, 1 / - 2, -10000, 10000 );
         this.camera.position.z = 10;


### PR DESCRIPTION
Since we modify the coordinates in the shaders (using scales), the
coordinates for threejs can mislead it to think it's outside the
frustum/viewport.

Fixes the issues described in https://github.com/glue-viz/glue-jupyter/pull/227