### PR TITLE
fix: MouseInteraction would remove all listeners in .off

### DIFF
--- a/js/lib/MouseInteraction.js
+++ b/js/lib/MouseInteraction.js
@@ -185,7 +185,7 @@ class MouseInteraction extends Interaction_1.Interaction {
             this.nextView.remove();
         }
         this.unbindEvents();
-        this.parent.off('margin_updated', this.updateScaleRanges);
+        this.parent.off('margin_updated', this.updateScaleRanges, this);
         this.parent.el.removeAttribute("tabindex");
         this._emitThrottled.flush();
     }


### PR DESCRIPTION
This caused 1 MouseInteraction that would be removed to remove the
event listeners of all other MouseInteractions.

Fixes the issue @kecnry mentioned in https://github.com/spacetelescope/jdaviz/pull/1013 because the domain would not be updated any more.
