### PR TITLE
Fix visibility toggle in LinesGL

### DIFF
--- a/js/lib/linesgl.js
+++ b/js/lib/linesgl.js
@@ -85,6 +85,16 @@ class LinesGLView extends bqplot.Lines {
 
         return result;
     }
+
+    create_listeners() {
+        super.create_listeners();
+        var sync_visible = () => {
+            this.material.visible = this.model.get('visible');
+            this.update_scene();
+        };
+        this.listenTo(this.model, "change:visible", sync_visible , this);
+    }
+    
     _updateGeometry() {
         const scalar_names = ["x", "y", "z"];
         const vector4_names = [];


### PR DESCRIPTION
## Description

LinesGL wasn't respecting visibility toggling from the front end. In non-GL bqplot both the image and lines marks inherit this behavior from `Marks`, but it seems like here it isn't getting inherited properly, since there was already code to do this in `imagegl.js`. This adds the equivalent code to `linesgl.js`, although it would be more elegant to have them both inherit the behavior properly.
