### PR TITLE
fix: allow over 8 orders of magnitude in zooming

### DIFF
--- a/js/shaders/scales-delta.glsl
+++ b/js/shaders/scales-delta.glsl
@@ -1,0 +1,33 @@
+// these scale transformations use a vec3 for the domain where the last element [2] contains the delta
+// where for the log version, it contains log(domain[1]) - log(domain[0]).
+// This avoids rounding issues when using float32 math on the GPU, since
+// dividing by (domain[1] - domain[0]) can becomes a division by zero when
+// domain[1] - is in the range domain[0] * (1 + 1e-8), i.e. the relative float32
+// precision.
+// Instead, we compute the delta in Javascript, which uses float64.
+// This allows us to zoom into a line plot with abound 14 orders of magnitude
+// at around 1e15-1e16 we also start seeing rounding issues with float64.
+
+float scale_transform_linear(float domain_value, vec2 range, vec3 domain) {
+    float normalized = (domain_value - domain[0]) / (domain[2]);
+    float range_value = normalized * (range[1] - range[0]) + range[0];
+    return range_value;
+}
+
+float scale_transform_linear_inverse(float range_value, vec2 range, vec3 domain) {
+    float normalized = (range_value - range[0]) / (range[1] - range[0]);
+    float domain_value = normalized * (domain[2]) + domain[0];
+    return domain_value;
+}
+
+float scale_transform_log(float domain_value, vec2 range, vec3 domain) {
+    float normalized = (log(domain_value) - log(domain[0])) / (domain[2]);
+    float range_value = normalized * (range[1] - range[0]) + range[0];
+    return range_value;
+}
+
+float scale_transform_log_inverse(float range_value, vec2 range, vec3 domain) {
+    float normalized = (range_value - range[0]) / (range[1] - range[0]);
+    float domain_value = exp(normalized * (log(domain[1]) - log(domain[0])) + log(domain[0]));
+    return domain_value;
+}

--- a/js/shaders/scales-extra.glsl
+++ b/js/shaders/scales-extra.glsl
@@ -3,7 +3,7 @@
 #define SCALE_TYPE_LOG 2
 
 #ifdef USE_SCALE_X
-    uniform vec2 domain_x;
+    uniform vec3 domain_x;
     uniform vec2 range_x;
     #if SCALE_TYPE_x == SCALE_TYPE_LINEAR
         #define SCALE_X(x) scale_transform_linear(x, range_x, domain_x)
@@ -13,7 +13,7 @@
 #endif
 
 #ifdef USE_SCALE_Y
-    uniform vec2 domain_y;
+    uniform vec3 domain_y;
     uniform vec2 range_y;
     #if SCALE_TYPE_y == SCALE_TYPE_LINEAR
         #define SCALE_Y(x) scale_transform_linear(x, range_y, domain_y)


### PR DESCRIPTION
see scales-delta.glsl for details.

The issues could be exposed using:
```python
import numpy as np
from bqplot import Figure, LinearScale, Axis, ColorScale, Lines
from bqplot_image_gl import LinesGL
import ipywidgets as widgets

N = int(1e5)
x = np.arange(N) * 100 + 1e9
y = np.cumsum(np.random.random(N)*2-1)
y -= y.mean()

scale_x = LinearScale(min=x.min(), max=x.min()+1, allow_padding=False)
scale_y = LinearScale(allow_padding=False)
scales = {'x': scale_x, 'y': scale_y}
axis_x = Axis(scale=scale_x, label='x')
axis_y = Axis(scale=scale_y, label='y', orientation='vertical')
line_gl = LinesGL(x=x, y=y, scales=scales, colors=['orange'])
marks = [line_gl]
figure = Figure(scales=scales, axes=[axis_x, axis_y], marks=marks)
display(figure)
```

Fixes https://github.com/spacetelescope/jdaviz/issues/1177
