### PR TITLE
BUG: Remove non-existing import

### DIFF
--- a/bqplot_image_gl/__init__.py
+++ b/bqplot_image_gl/__init__.py
@@ -1,4 +1,4 @@
-from ._version import version_info, __version__  # noqa
+from ._version import __version__  # noqa
 
 from .imagegl import *  # noqa
 from .linesgl import *  # noqa


### PR DESCRIPTION
## Description

Jdaviz is unable to use the latest release.

```File .../bqplot_image_gl/__init__.py:1, in <module>
----> 1 from ._version import version_info, __version__  # noqa
      3 from .imagegl import *  # noqa
      4 from .linesgl import *  # noqa

ImportError: cannot import name 'version_info' from 'bqplot_image_gl._version' 
```

cc @maartenbreddels @rosteen @orifox