### PR TITLE
Use instance instead of class for trait

### DIFF
--- a/bqplot_image_gl/interacts.py
+++ b/bqplot_image_gl/interacts.py
@@ -99,5 +99,5 @@ class MouseInteraction(Interaction):
     cursor = Unicode('auto').tag(sync=True)
     move_throttle = Int(50).tag(sync=True)
     next = Instance(Interaction, allow_none=True).tag(sync=True, **widget_serialization)
-    events = List(Unicode, default_value=drag_events + mouse_events + keyboard_events,
+    events = List(Unicode(), default_value=drag_events + mouse_events + keyboard_events,
                   allow_none=True).tag(sync=True)


### PR DESCRIPTION
# Pull Request Template

## Description

I was getting a `DeprecationWarning` in the tests for astrowidgets because `bqplot_image_gl` was using an instance instead of a class.

This change fixes the warning.

### Traceback before the fix

```python-traceback
collected 0 items / 1 error

======================================================================= ERRORS ========================================================================
_______________________________________________ ERROR collecting astrowidgets/tests/test_bqplot_api.py ________________________________________________
astrowidgets/tests/test_bqplot_api.py:10: in <module>
    from astrowidgets.bqplot import ImageWidget, ALLOWED_CURSOR_LOCATIONS
astrowidgets/bqplot.py:16: in <module>
    from bqplot_image_gl.interacts import (MouseInteraction,
../../miniconda3/envs/awid/lib/python3.10/site-packages/bqplot_image_gl/interacts.py:61: in <module>
    class MouseInteraction(Interaction):
../../miniconda3/envs/awid/lib/python3.10/site-packages/bqplot_image_gl/interacts.py:102: in MouseInteraction
    events = List(Unicode, default_value=drag_events + mouse_events + keyboard_events,
../../miniconda3/envs/awid/lib/python3.10/site-packages/traitlets/traitlets.py:2825: in __init__
    super().__init__(trait=trait, default_value=default_value, **kwargs)
../../miniconda3/envs/awid/lib/python3.10/site-packages/traitlets/traitlets.py:2675: in __init__
    warn(
E   DeprecationWarning: Traits should be given as instances, not types (for example, `Int()`, not `Int`). Passing types is deprecated in traitlets 4.1.
```


