### PR TITLE
fix: ViewListener did not work with multiple frontends.

### DIFF
--- a/bqplot_image_gl/viewlistener.py
+++ b/bqplot_image_gl/viewlistener.py
@@ -18,3 +18,17 @@ class ViewListener(widgets.DOMWidget):
     widget = Instance(widgets.Widget).tag(sync=True, **widget_serialization)
     css_selector = Unicode(None, allow_none=True).tag(sync=True)
     view_data = Dict().tag(sync=True)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.on_msg(self._on_custom_msg)
+
+    def _on_custom_msg(self, widget, content, buffers=None):
+        if content.get('event', '') == 'set_view_data':
+            id = content['id']
+            data = content['data']
+            self.view_data = {**self.view_data, id: data}
+        elif content.get('event', '') == 'remove_view_data':
+            id = content['id']
+            new_view_data = {k: v for k, v in self.view_data.items() if k != id}
+            self.view_data = new_view_data


### PR DESCRIPTION
A single frontend is not aware of other frontends, therefore we cannot
mutate the `view_data` dict in the frontend.
Instead, we send messages to the kernel to update or remote entries.

Fixes https://github.com/spacetelescope/jdaviz/issues/1567
