### PR TITLE
ci: add missing notebook dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,11 @@ changedir =
 deps =
     test: pytest
     test: pytest-cov
+    test: notebook
     notebooks: numpy
     notebooks: ipyvuetify
     notebooks: scikit-image
+    notebooks: notebook
     # NOTE: the following is a temporary fix for the issue described in
     # https://github.com/voila-dashboards/voila/issues/728
     # and should be removed once the issue is fixed in jupyter-server


### PR DESCRIPTION
## Description

This PR fixes CI failing on a missing notebook dependency. See https://github.com/glue-viz/bqplot-image-gl/actions/runs/4633257742