### PR TITLE
feat: resize & focus tracking in view_data

### DIFF
--- a/bqplot_image_gl/viewlistener.py
+++ b/bqplot_image_gl/viewlistener.py
@@ -2,8 +2,16 @@ import ipywidgets as widgets
 from ipywidgets.widgets import widget_serialization
 from traitlets import Unicode, Dict, Instance
 from bqplot_image_gl._version import __version__
+from typing import TypedDict, cast, Dict as DictType
 
 __all__ = ['ViewListener']
+
+
+class ViewDataEntry(TypedDict):
+    x: float
+    y: float
+    width: float
+    height: float
 
 
 @widgets.register
@@ -17,7 +25,7 @@ class ViewListener(widgets.DOMWidget):
 
     widget = Instance(widgets.Widget).tag(sync=True, **widget_serialization)
     css_selector = Unicode(None, allow_none=True).tag(sync=True)
-    view_data = Dict().tag(sync=True)
+    view_data = Dict(value_trait=cast(DictType[str, ViewDataEntry], {})).tag(sync=True)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/bqplot_image_gl/viewlistener.py
+++ b/bqplot_image_gl/viewlistener.py
@@ -2,7 +2,8 @@ import ipywidgets as widgets
 from ipywidgets.widgets import widget_serialization
 from traitlets import Unicode, Dict, Instance
 from bqplot_image_gl._version import __version__
-from typing import TypedDict, cast, Dict as DictType
+from typing import cast, Dict as DictType
+from typing_extensions import TypedDict
 
 __all__ = ['ViewListener']
 
@@ -12,6 +13,8 @@ class ViewDataEntry(TypedDict):
     y: float
     width: float
     height: float
+    resized_at: str  # ISO 8601
+    focused_at: str  # ISO 8601
 
 
 @widgets.register


### PR DESCRIPTION
# Pull Request Template

## Description

Stores timestamps `resized_at` and `focused_at` in `view_data`. This is useful to track which viewer figures should have their shape set based on.

@maartenbreddels and others I welcome discussion / feedback on the focus portion in particular:
- Should we also track the last point at which focus entered a view?
- Is there any need to remove the eventListener from window?