### PR TITLE
[codex] restore bqplot 0.13 Lab 3 coverage and require bqplot-gl 0.1.1

### DIFF
--- a/js/lib/bqplot-gl-loader-classic.js
+++ b/js/lib/bqplot-gl-loader-classic.js
@@ -3,11 +3,11 @@ function loadBqplotGL() {
     // this AMD-only prevents bqplot 0.12 from fetching bqplot-gl eagerly.
     var amdRequire = typeof window !== "undefined" && (window.requirejs || window.require);
     if(!amdRequire) {
-        return Promise.reject(new Error("bqplot-image-gl with bqplot 0.13 requires bqplot-gl. Install and enable bqplot-gl, or use bqplot 0.12."));
+        return Promise.reject(new Error("bqplot-image-gl loaded its classic bqplot-gl bridge without a RequireJS loader."));
     }
     return new Promise((resolve, reject) => {
         amdRequire(["bqplot-gl"], resolve, () => {
-            reject(new Error("bqplot-image-gl with bqplot 0.13 requires bqplot-gl. Install and enable bqplot-gl, or use bqplot 0.12."));
+            reject(new Error("bqplot-image-gl with bqplot 0.13 requires bqplot-gl. Install bqplot-gl and enable its nbextension for classic frontends, or use bqplot 0.12."));
         });
     });
 }

--- a/js/lib/bqplot-gl-loader.js
+++ b/js/lib/bqplot-gl-loader.js
@@ -2,7 +2,7 @@ function loadBqplotGL() {
     // JupyterLab 4 resolves separately installed widget packages through
     // module federation, so the labextension bundle must use dynamic import.
     return import("bqplot-gl").catch(() => {
-        throw new Error("bqplot-image-gl with bqplot 0.13 requires bqplot-gl. Install and enable bqplot-gl, or use bqplot 0.12.");
+        throw new Error("bqplot-image-gl with bqplot 0.13 requires bqplot-gl. Install bqplot-gl so JupyterLab can load its labextension, or use bqplot 0.12.");
     });
 }
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bqplot-image-gl",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bqplot-image-gl",
-      "version": "1.9.2",
+      "version": "1.10.0",
       "hasInstallScript": true,
       "dependencies": {
         "@jupyter-widgets/base": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4 || ^6",
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "@jupyterlab/builder": "^3.0.0-rc.4 || ^4.0.0",
-        "bqplot-gl": "^0.1.0",
+        "bqplot-gl": "^0.1.1",
         "npm-run-all": "^4.1.5",
         "raw-loader": "^4",
         "rimraf": "^6.1.3",
@@ -32,7 +32,7 @@
         "webpack-cli": "^7"
       },
       "peerDependencies": {
-        "bqplot-gl": ">=0.1.0 <0.2.0"
+        "bqplot-gl": ">=0.1.1 <0.2.0"
       },
       "peerDependenciesMeta": {
         "bqplot-gl": {
@@ -1083,9 +1083,9 @@
       }
     },
     "node_modules/bqplot-gl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bqplot-gl/-/bqplot-gl-0.1.0.tgz",
-      "integrity": "sha512-vppqFCmjndc3IRDc/nijQftFr/FBSRt+u7zCpabwMIMGxoNC97R86T8AUfSdfYFqg/AVHoLeFU7ViaEAQl99Xg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bqplot-gl/-/bqplot-gl-0.1.1.tgz",
+      "integrity": "sha512-M/k7T4TADW5HT2cvN+QzCODeOlvN6LSaOx0fQ9xXaHXqvek1GsLBujhcE/zhV2W/MqeJOxNoIt2iDIyTc5X+fg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.0-rc.4 || ^4.0.0",
-    "bqplot-gl": "^0.1.0",
+    "bqplot-gl": "^0.1.1",
     "npm-run-all": "^4.1.5",
     "raw-loader": "^4",
     "rimraf": "^6.1.3",
@@ -55,7 +55,7 @@
     "three": "^0.97.0"
   },
   "peerDependencies": {
-    "bqplot-gl": ">=0.1.0 <0.2.0"
+    "bqplot-gl": ">=0.1.1 <0.2.0"
   },
   "peerDependenciesMeta": {
     "bqplot-gl": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "jupyterlab>=3.6",
+    "jupyterlab>=3.6,<4",
     "hatchling",
     "hatch-jupyter-builder>=0.5.0",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ isolated_build = true
 
 [testenv]
 setenv =
-    bqplot013: SOLARA_TEST_RUNNERS = solara,jupyter_notebook
+    bqplot013: SOLARA_TEST_RUNNERS = solara,jupyter_notebook,jupyter_lab
 changedir =
     test: .tmp/{envname}
     notebooks: examples
@@ -27,7 +27,7 @@ deps =
     bqplot013: notebook<7
     bqplot013: bqplot>=0.13,<0.14
     bqplot013: bqplot-gl @ git+https://github.com/maartenbreddels/bqplot-gl.git@codex/export-webgl-figure-init
-    bqplot013: jupyterlab>=4,<5
+    bqplot013: jupyterlab<4
 extras =
     test: test
     notebooks: test

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     bqplot013: solara>=1.44.1
     bqplot013: notebook<7
     bqplot013: bqplot>=0.13,<0.14
-    bqplot013: bqplot-gl @ git+https://github.com/maartenbreddels/bqplot-gl.git@codex/export-webgl-figure-init
+    bqplot013: bqplot-gl>=0.1.1
     bqplot013: jupyterlab<4
 extras =
     test: test


### PR DESCRIPTION
## Summary

This is a follow-up to the bqplot 0.12/0.13 compatibility work that was merged before the final CI cleanup landed.

The previous PR added bqplot 0.13 coverage but temporarily skipped the JupyterLab runner for that environment while we worked through the runtime/package split. That left the bqplot 0.13 visual job testing Solara and classic Notebook, but not the historical JupyterLab path.

## Details

This restores JupyterLab coverage for the bqplot 0.13 visual environment while keeping it on JupyterLab 3. That matches the JupyterLab major version the project has historically tested, and avoids mixing the current compatibility PR with the separate JupyterLab 4 federated-extension problem.

The build-system dependency is also pinned to `jupyterlab>=3.6,<4`. Without the upper bound, isolated builds can pull JupyterLab 4 to build the labextension metadata, even when the test environment itself is running JupyterLab 3. That mismatch produced confusing shared-package warnings in the browser and made it look like the runtime was testing one thing while the built bundle expected another.

I also clarified the bqplot-gl loader error messages. The classic loader now distinguishes between “there is no RequireJS loader” and “bqplot-gl is missing from the classic frontend”, while the JupyterLab loader message no longer tells users to enable an nbextension.

## Validation

- `npm run build` passed using JupyterLab 3.5.2 on PATH.
- Earlier local Docker checks showed the bqplot 0.13 JupyterLab runner renders under JupyterLab 3; the remaining image mismatch was from the existing JupyterLab news/privacy toast baseline and was intentionally not included in this minimized follow-up.
