### PR TITLE
Avoid geometry id collisions with bqplot's copy of three.js

### DIFF
--- a/js/lib/index.js
+++ b/js/lib/index.js
@@ -1,5 +1,8 @@
 /*jshint esversion: 6 */
 
+// Must run before any mark view creates three.js objects.
+import "./three-id-offset.js";
+
 // Export widget models and views, and the npm package version number.
 export * from "./imagegl.js";
 export * from "./linesgl.js";

--- a/js/lib/three-id-offset.js
+++ b/js/lib/three-id-offset.js
@@ -1,0 +1,21 @@
+/*jshint esversion: 6 */
+
+var THREE = require('three');
+
+// bqplot draws GL marks from this package with the figure's shared
+// THREE.WebGLRenderer, which caches geometries keyed by the numeric
+// geometry.id. Every copy of three.js assigns ids from its own module-level
+// counter, so a geometry created here can receive the same id as a bqplot
+// geometry and silently claim its slot in the renderer cache, making the
+// other mark draw the wrong geometry (seen as a scatter viewer that stays
+// empty until its marks are recreated). patches/three+0.97.0.patch offsets
+// the counters of the three.js copy bundled with this package, but under
+// module federation the "three" this module receives can be another
+// extension's unpatched copy of the same version (for example ipyvolume's or
+// pythreejs'), so the offset has to be applied at runtime to whichever copy
+// is actually in use. geometry.id is defined non-configurable and cannot be
+// reassigned per object; creating throwaway geometries is the only way to
+// advance the counter (around 30 ms for 50000 of them).
+for (var i = 0; i < 50000; i++) {
+    new THREE.BufferGeometry();
+}


### PR DESCRIPTION
This fix was prepared by Claude (Fable) to try and resolve a long-standing bug in glue which is that on first show, ScatterGL points do not show up correctly in glue. Here is Claude's summary:

> This fixes the long-standing "first scatter viewer is empty until its cell is re-run" bug in glue-jupyter (glue-viz/glue-jupyter#353), and the equivalent failure for any figure that mixes marks from this package with bqplot GL marks.
> 
> bqplot draws GL marks from this package through the figure's shared `THREE.WebGLRenderer`, which caches geometries keyed by the numeric `geometry.id`. Each copy of three.js assigns ids from its own module-level counter, so in a fresh page the first geometry created by each copy gets the same id (3). The ImageGL density mark renders first and claims the cache slot, and the ScatterGL mark is then silently drawn with the plane geometry instead of its instanced one: a blank plot with no errors, correct model state, and correct buffers. Re-running the cell works because both counters have advanced unevenly by then, which is why the bug only ever affects the first viewer in a freshly loaded page.
> 
> This was already addressed in 2021 by `patches/three+0.97.0.patch`, which offsets the id counters of the three.js copy bundled here. However, under JupyterLab module federation other extensions (for example ipyvolume and pythreejs) also provide an unpatched `three@0.97.0`, and only one provider wins per version key, so at runtime this package can receive an unpatched copy and the patch never takes effect. Since glue-jupyter depends on ipyvolume, that is the common case there.
> 
> `geometry.id` is defined non-configurable, so it cannot be reassigned per object. Instead, a new module imported before anything else creates 50000 throwaway `BufferGeometry` objects at load time (about 30 ms), advancing the counter of whichever three.js copy is actually consumed so its ids start at 100003 and stay far beyond anything the bqplot copy will realistically reach (the margin is exceeded only if bqplot creates 50000+ geometries in a single page lifetime). The existing patch is kept for the case where the bundled copy is used. Side effect worth noting: other extensions sharing the same three.js instance will also hand out larger ids, which is harmless since ids are only used as cache and sort keys.
> 
> Verified against a headless JupyterLab + Playwright reproduction of the glue-jupyter demo notebook: before this change the first run always produced an empty scatter (ids 3 vs 3, single non-instanced draw call); with it, the first run renders all points (ids 100003 vs 3).